### PR TITLE
Homepage and poll component

### DIFF
--- a/src/AppStyles.css
+++ b/src/AppStyles.css
@@ -21,7 +21,6 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   min-height: 100vh;
 }
 

--- a/src/components/Home.css
+++ b/src/components/Home.css
@@ -1,0 +1,6 @@
+.polls-container {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    width: 90%;
+}

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -59,9 +59,14 @@ const Home = () => {
   function filterNonDraftPolls() {
     setNonDraftPolls(
       MOCK_POLL_DATA.filter(
-        (poll) => poll.status !== "draft" || poll.status !== "disabled",
+        (poll) => poll.status !== "draft" && poll.status !== "disabled",
       ),
     );
+  }
+
+  function generateKey(num) {
+    const date = new Date();
+    return date.getTime() + num;
   }
 
   useEffect(() => {
@@ -73,13 +78,9 @@ const Home = () => {
 
   return (
     <div className="polls-container">
-      {nonDraftPolls.map((poll) =>
-        poll.status === "ended" ? (
-          <Poll pollData={poll} />
-        ) : (
-          <Poll pollData={poll} />
-        ),
-      )}
+      {nonDraftPolls.map((poll, index) => (
+        <Poll pollData={poll} key={generateKey(index)} />
+      ))}
     </div>
   );
 };

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,11 +1,86 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import Poll from "./Poll";
+import "./Home.css";
 
 const Home = () => {
+  const MOCK_POLL_DATA = [
+    {
+      pollId: 0,
+      title: "Poll 1",
+      description: "Description for Poll 1",
+      status: "draft",
+      endDate: new Date("07/20/2025"),
+      sumOfVotes: 5,
+    },
+    {
+      pollId: 1,
+      title: "Poll 2",
+      description: "Description for Poll 2",
+      status: "published",
+      endDate: new Date("07/25/2025"),
+      sumOfVotes: 5,
+    },
+    {
+      pollId: 2,
+      title: "Poll 3",
+      description: "Description for Poll 3",
+      status: "published",
+      endDate: new Date("08/05/2025"),
+      sumOfVotes: 5,
+    },
+    {
+      pollId: 3,
+      title: "Poll 4",
+      description: "Description for Poll 4",
+      status: "ended",
+      endDate: new Date("08/09/2025"),
+      sumOfVotes: 5,
+    },
+    {
+      pollId: 4,
+      title: "Poll 5",
+      description: "Description for Poll 5",
+      status: "ended",
+      endDate: new Date("08/19/2025"),
+      sumOfVotes: 3,
+    },
+    {
+      pollId: 5,
+      title: "Poll 6",
+      description: "Description for Poll 6",
+      status: "ended",
+      endDate: new Date("09/12/2025"),
+      sumOfVotes: 10,
+    },
+  ];
+
+  const [nonDraftPolls, setNonDraftPolls] = useState([]);
+
+  function filterNonDraftPolls() {
+    setNonDraftPolls(
+      MOCK_POLL_DATA.filter(
+        (poll) => poll.status !== "draft" || poll.status !== "disabled",
+      ),
+    );
+  }
+
+  useEffect(() => {
+    // The fetch call will run through here for the initial DB poll data.
+
+    // This function could maybe work instead inside of the async function that calls the api req.
+    filterNonDraftPolls();
+  }, []);
+
   return (
-    <>
-      <h1>Hello React!</h1>
-      <img className="react-logo" src="/react-logo.svg" alt="React Logo" />
-    </>
+    <div className="polls-container">
+      {nonDraftPolls.map((poll) =>
+        poll.status === "ended" ? (
+          <Poll pollData={poll} />
+        ) : (
+          <Poll pollData={poll} />
+        ),
+      )}
+    </div>
   );
 };
 

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -52,6 +52,22 @@ const Home = () => {
       endDate: new Date("09/12/2025"),
       sumOfVotes: 10,
     },
+
+  
+
+ {
+      pollId: 6,
+      title: "Poll 7",
+      description: "Description for Poll 6",
+      status: "ended",
+      endDate: new Date("09/12/2025"),
+      sumOfVotes: 10,
+    },
+
+
+  
+
+
   ];
 
   const [nonDraftPolls, setNonDraftPolls] = useState([]);

--- a/src/components/Poll.css
+++ b/src/components/Poll.css
@@ -1,0 +1,20 @@
+.poll-card {
+    border: 1px solid black;
+    margin: 10px;
+    width: 240px;
+    cursor: pointer;
+}
+
+.poll-heading {
+    margin: 10px 0;
+    text-align: center;
+}
+.status-text {
+    width: 100%;
+    text-align: center;
+    font-style: italic;
+    font-weight: bold;
+    font-size: 24px;
+    padding: 4px;
+    border-bottom: 1px solid black;
+}

--- a/src/components/Poll.jsx
+++ b/src/components/Poll.jsx
@@ -11,6 +11,12 @@ Data Needed(for now):
 - endDate
 - sumOfVotes
 */
+const statusText = {
+  draft: "Continue your ballot...",
+  published: "Vote!",
+  ended: "Voting has Ended!",
+  disabled: "This Poll has been disabled.",
+};
 
 export default function Poll({ pollData }) {
   const navigate = useNavigate();
@@ -19,14 +25,20 @@ export default function Poll({ pollData }) {
   function handleClick(event) {
     event.preventDefault();
     // This navigate wont navigate to anything until the vote page component is done
-    navigate(`/voting-page/${pollData.pollId}`);
+
+    if (pollData.status === "published") {
+      // If the poll is still in effect, clicking the poll will take you to the Voting Page
+      navigate(`/voting-page/${pollData.pollId}`);
+    } else if (pollData.status === "ended") {
+      // If the poll is not in effect, clicking the poll will take you to the Ranking Results Page
+      // This route of "ranking-results" doesnt have to be final, just an idea.
+      navigate(`/ranking-results/${pollData.pollId}`);
+    }
   }
 
   return (
     <div className="poll-card" onClick={handleClick}>
-      <p className="status-text">
-        {pollData.status === "published" ? "Vote!" : "Poll has Ended!"}
-      </p>
+      <p className="status-text">{statusText[pollData.status]}</p>
       <h1 className="poll-heading">{pollData.title}</h1>
       <p>{pollData.description}</p>
       <p>EndDate: {pollData.endDate.toLocaleString()}</p>

--- a/src/components/Poll.jsx
+++ b/src/components/Poll.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import "./Poll.css";
+
+/*
+Data Needed(for now):
+- Poll ID (not used within the element)
+- Title
+- Description
+- status: (DRAFT, PUBLISHED, ENDED, DISABLED)
+- endDate
+- sumOfVotes
+*/
+
+export default function Poll({ pollData }) {
+  const navigate = useNavigate();
+
+  // This function will run when a poll is clicked on
+  function handleClick(event) {
+    event.preventDefault();
+    // This navigate wont navigate to anything until the vote page component is done
+    navigate(`/voting-page/${pollData.pollId}`);
+  }
+
+  return (
+    <div className="poll-card" onClick={handleClick}>
+      <p className="status-text">
+        {pollData.status === "published" ? "Vote!" : "Poll has Ended!"}
+      </p>
+      <h1 className="poll-heading">{pollData.title}</h1>
+      <p>{pollData.description}</p>
+      <p>EndDate: {pollData.endDate.toLocaleString()}</p>
+      <p>Votes thus far: {pollData.sumOfVotes}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
The poll component is very ugly right now but does the basics:

- Will print relevant info to a Poll Card component (Title, desc, end date, etc.)
- Print the corresponding text based on the status of the poll

The Poll component also navigates to the proper page based on status when on the Homepage view.

- When the status of a poll is "published", clicking the poll will send the user to route '/voting-page/:POLLID'
- When the status of a poll is "ended", clicking the poll will send the user to route '/ranking-results/:POLLID'

The ranking results page route is not final just what I put in for now

The `Homepage` component should not show any "draft" or "disabled" polls. Feel free to add to the fake poll array to test it.